### PR TITLE
Fix AI enhancement parameter error in edit form

### DIFF
--- a/components/family/EditFamilyHabitModal.tsx
+++ b/components/family/EditFamilyHabitModal.tsx
@@ -73,11 +73,11 @@ export function EditFamilyHabitModal({ isOpen, onClose, habit, onSuccess }: Edit
     setError(null);
 
     try {
-      const response = await enhanceHabit({
-        habitName: formData.name.trim(),
-        category: 'general', // You could make this dynamic based on the habit
-        existingHabits: []
-      });
+      const response = await enhanceHabit(
+        formData.name.trim(),
+        'general', // You could make this dynamic based on the habit
+        []
+      );
 
       if (response?.success && response.data) {
         setAiEnhancement(response.data);


### PR DESCRIPTION
## 🐛 Bugfix

**Issue**:  when using AI enhancement in family habit edit form

**Root Cause**: Parameter mismatch between useClaudeAI hook signature and function call

**Solution**: 
- Fixed enhanceHabit function call to use correct parameter signature
- Changed from object parameter to separate string parameters
- Maintains consistency with hook interface

**Impact**: AI enhancement now works properly in both create and edit forms

🤖 Generated with [Claude Code](https://claude.ai/code)